### PR TITLE
add robots meta

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,12 @@ import { createApp } from "vue";
 import { createPinia } from "pinia";
 import router from "@/router";
 import App from "@/App.vue";
+import blockIndex from "@/utils/robotsNoIndex";
 
 const app = createApp(App);
 app.use(createPinia());
 app.use(router);
 
 app.mount("#app");
+
+blockIndex();

--- a/src/utils/robotsNoIndex.ts
+++ b/src/utils/robotsNoIndex.ts
@@ -1,0 +1,11 @@
+function blockIndex() {
+  const devDeploy = import.meta.env.VITE_DEV_DEPLOY;
+  if (devDeploy) {
+    const meta = document.createElement('meta');
+    meta.name = "robots";
+    meta.content = "noindex";
+    document.getElementsByTagName('head')[0].appendChild(meta);
+  }
+}
+
+export default blockIndex;


### PR DESCRIPTION
Генерирует метатег <meta name="robots" content="noindex" /> в head приложения для dev деплоев.
Данный тег запрещает индексацию страниц поисковыми машинами, чтобы наши технические деплои не попадали в поисковую выдачу. Немного об этом здесь https://racurs.agency/blog/seo/polnoe-rukovodstvo-po-metategam-robots-i-zagolovku-x-robots-tag/
В идеале хотелось бы также генерировать разный robots.txt в зависимости от среды, но пока не нашла решения именно для Vue